### PR TITLE
#76 Overriden GetHashCode/Equals calls base 'Object.GetHashCode/Equal…

### DIFF
--- a/src/SonarLint/Rules.Description/S3249.html
+++ b/src/SonarLint/Rules.Description/S3249.html
@@ -1,0 +1,38 @@
+<p>
+    Making a <code>base</code> call in an overridden method is generally a good idea, but not in <code>GetHashCode</code> and
+    <code>Equals</code> for classes that directly extend <code>Object</code> because those methods are based on the object reference.
+    Meaning that no two <code>Objects</code> that use those <code>base</code> methods will ever be equal or have the same hash.
+</p>
+
+<h2>Noncompliant Code Example</h2>
+<pre>
+public class Point
+{
+  private readonly int x;
+  public MyClass(int x)
+  {
+    this.x = x;
+  }
+  public override int GetHashCode()
+  {
+    return x.GetHashCode() ^ base.GetHashCode(); //Noncompliant
+  }
+}
+</pre>
+
+<h2>Compliant Solution</h2>
+<pre>
+public class Point
+{
+  private readonly int x;
+  public MyClass(int x)
+  {
+    this.x = x;
+  }
+  public override int GetHashCode()
+  {
+    return x.GetHashCode();
+  }
+}
+</pre>
+

--- a/src/SonarLint/Rules/GetHashCodeEqualsOverride.cs
+++ b/src/SonarLint/Rules/GetHashCodeEqualsOverride.cs
@@ -1,0 +1,118 @@
+﻿/*
+ * SonarLint for Visual Studio
+ * Copyright (C) 2015 SonarSource
+ * sonarqube@googlegroups.com
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02
+ */
+
+using System.Collections.Immutable;
+using System.Linq;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+using Microsoft.CodeAnalysis.Diagnostics;
+using SonarLint.Common;
+using SonarLint.Common.Sqale;
+using SonarLint.Helpers;
+
+namespace SonarLint.Rules
+{
+    [DiagnosticAnalyzer(LanguageNames.CSharp)]
+    [SqaleConstantRemediation("15min")]
+    [SqaleSubCharacteristic(SqaleSubCharacteristic.LogicReliability)]
+    [Rule(DiagnosticId, RuleSeverity, Title, IsActivatedByDefault)]
+    [Tags("bug")]
+    public class GetHashCodeEqualsOverride : DiagnosticAnalyzer
+    {
+        internal const string DiagnosticId = "S3249";
+        internal const string Title = "Classes directly  extending \"Object\" should not call \"base\" in \"GetHashCode\" or \"Equals\"";
+        internal const string Description =
+            "Making a \"base\" call in an overridden method is generally a good idea, but not in \"GetHashCode\" and \"Equals\" for " +
+            "classes that directly extend \"Object\" because those methods are based on the object reference. Meaning that no two \"Objects\" " +
+            "that use those \"base\" methods will ever be equal or have the same hash.";
+        internal const string MessageFormat = "Remove this \"base\" call.";
+        internal const string Category = "SonarQube";
+        internal const Severity RuleSeverity = Severity.Critical;
+        internal const bool IsActivatedByDefault = true;
+
+        internal static readonly DiagnosticDescriptor Rule =
+            new DiagnosticDescriptor(DiagnosticId, Title, MessageFormat, Category,
+                RuleSeverity.ToDiagnosticSeverity(), IsActivatedByDefault,
+                helpLinkUri: DiagnosticId.GetHelpLink(),
+                description: Description);
+
+        public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics { get { return ImmutableArray.Create(Rule); } }
+
+        private static readonly string[] MethodNames = { "GetHashCode", "Equals" };
+
+        public override void Initialize(AnalysisContext context)
+        {
+            context.RegisterCodeBlockStartAction<SyntaxKind>(
+                cb =>
+                {
+                    var methodDeclaration = cb.CodeBlock as MethodDeclarationSyntax;
+                    if (methodDeclaration == null)
+                    {
+                        return;
+                    }
+
+                    var methodSymbol = cb.OwningSymbol as IMethodSymbol;
+                    if (methodSymbol == null ||
+                        !MethodIsRelevant(methodSymbol))
+                    {
+                        return;
+                    }
+
+                    cb.RegisterSyntaxNodeAction(
+                        c =>
+                        {
+                            var invocation = (InvocationExpressionSyntax)c.Node;
+                            var invokedMethod = c.SemanticModel.GetSymbolInfo(invocation).Symbol as IMethodSymbol;
+                            if (invokedMethod == null ||
+                                invokedMethod.Name != methodSymbol.Name)
+                            {
+                                return;
+                            }
+
+                            var memberAccess = invocation.Expression as MemberAccessExpressionSyntax;
+                            if (memberAccess == null)
+                            {
+                                return;
+                            }
+
+                            var baseCall = memberAccess.Expression as BaseExpressionSyntax;
+                            if (baseCall == null)
+                            {
+                                return;
+                            }
+
+                            var objectType = invokedMethod.ContainingType;
+                            if (objectType != null &&
+                                objectType.SpecialType == SpecialType.System_Object)
+                            {
+                                c.ReportDiagnostic(Diagnostic.Create(Rule, invocation.GetLocation()));
+                            }
+                        },
+                        SyntaxKind.InvocationExpression);
+                });
+        }
+
+        private static bool MethodIsRelevant(IMethodSymbol methodSymbol)
+        {
+            return MethodNames.Contains(methodSymbol.Name) && methodSymbol.IsOverride;
+        }
+    }
+}

--- a/src/SonarLint/SonarLint.csproj
+++ b/src/SonarLint/SonarLint.csproj
@@ -86,6 +86,7 @@
     <Compile Include="Helpers\EquivalenceChecker.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="Rules\UnaryPrefixOperatorRepeated.cs" />
+    <Compile Include="Rules\GetHashCodeEqualsOverride.cs" />
     <Compile Include="Rules\InsecureEncryptionAlgorithm.cs" />
     <Compile Include="Rules\SillyBitwiseOperation.cs" />
     <Compile Include="Rules\ConstructorOverridableCall.cs" />
@@ -407,6 +408,9 @@
       <Project>{741c2442-0401-4b83-8527-8c4d3bbc0e1c}</Project>
       <Name>SonarLint.Common</Name>
     </ProjectReference>
+  </ItemGroup>
+  <ItemGroup>
+    <EmbeddedResource Include="Rules.Description\S3249.html" />
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 

--- a/src/Tests/SonarLint.RulingTest/Expected/S3249.json
+++ b/src/Tests/SonarLint.RulingTest/Expected/S3249.json
@@ -1,0 +1,43 @@
+{
+  "Version": "0.1",
+  "ToolInfo": {
+    "ToolName": "SonarLint.RulingTest",
+    "FileVersion": "1.0.0"
+  },
+  "Issues": [
+    {
+      "RuleId": "S3249",
+      "FullMessage": "Remove this \"base\" call.",
+      "Locations": [
+        {
+          "AnalysisTarget": {
+            "Uri": "\\nuget\\src\\Core\\PackageSource\\PackageSource.cs",
+            "Region": {
+              "StartLine": 74,
+              "EndLine": 74,
+              "StartColumn": 0,
+              "EndColumn": 2147483647
+            }
+          }
+        }
+      ]
+    },
+    {
+      "RuleId": "S3249",
+      "FullMessage": "Remove this \"base\" call.",
+      "Locations": [
+        {
+          "AnalysisTarget": {
+            "Uri": "\\nuget\\src\\Core\\Runtime\\AssemblyBinding.cs",
+            "Region": {
+              "StartLine": 231,
+              "EndLine": 231,
+              "StartColumn": 0,
+              "EndColumn": 2147483647
+            }
+          }
+        }
+      ]
+    }
+  ]
+}

--- a/src/Tests/SonarLint.RulingTest/SonarLint.RulingTest.csproj
+++ b/src/Tests/SonarLint.RulingTest/SonarLint.RulingTest.csproj
@@ -379,6 +379,9 @@
     <None Include="Expected\S2997.json">
       <CopyToOutputDirectory>Always</CopyToOutputDirectory>
     </None>
+    <None Include="Expected\S3249.json">
+      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+    </None>
     <None Include="Expected\S907.json">
       <CopyToOutputDirectory>Always</CopyToOutputDirectory>
     </None>

--- a/src/Tests/SonarLint.UnitTest/Rules/GetHashCodeEqualsOverrideTest.cs
+++ b/src/Tests/SonarLint.UnitTest/Rules/GetHashCodeEqualsOverrideTest.cs
@@ -1,0 +1,36 @@
+﻿/*
+ * SonarLint for Visual Studio
+ * Copyright (C) 2015 SonarSource
+ * sonarqube@googlegroups.com
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02
+ */
+
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using SonarLint.Rules;
+
+namespace SonarLint.UnitTest.Rules
+{
+    [TestClass]
+    public class GetHashCodeEqualsOverrideTest
+    {
+        [TestMethod]
+        [TestCategory("Rule")]
+        public void GetHashCodeEqualsOverride()
+        {
+            Verifier.Verify(@"TestCases\GetHashCodeEqualsOverride.cs", new GetHashCodeEqualsOverride());
+        }
+    }
+}

--- a/src/Tests/SonarLint.UnitTest/SonarLint.UnitTest.csproj
+++ b/src/Tests/SonarLint.UnitTest/SonarLint.UnitTest.csproj
@@ -131,6 +131,7 @@
     <Compile Include="MetricsTest.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="Rules\UnaryPrefixOperatorRepeatedTest.cs" />
+    <Compile Include="Rules\GetHashCodeEqualsOverrideTest.cs" />
     <Compile Include="Rules\InsecureEncryptionAlgorithmTest.cs" />
     <Compile Include="Rules\SillyBitwiseOperationTest.cs" />
     <Compile Include="Rules\ConstructorOverridableCallTest.cs" />
@@ -360,6 +361,9 @@
       <CopyToOutputDirectory>Always</CopyToOutputDirectory>
     </None>
     <None Include="TestCases\UnaryPrefixOperatorRepeated.cs">
+      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+    </None>
+    <None Include="TestCases\GetHashCodeEqualsOverride.cs">
       <CopyToOutputDirectory>Always</CopyToOutputDirectory>
     </None>
     <Compile Include="Verifier.cs" />

--- a/src/Tests/SonarLint.UnitTest/TestCases/GetHashCodeEqualsOverride.cs
+++ b/src/Tests/SonarLint.UnitTest/TestCases/GetHashCodeEqualsOverride.cs
@@ -1,0 +1,70 @@
+﻿using System;
+using System.Collections.Generic;
+
+namespace Tests.Diagnostics
+{
+
+    class GetHashCodeEqualsOverride
+    {
+        private readonly int x;
+        public GetHashCodeEqualsOverride(int x)
+        {
+            this.x = x;
+        }
+        public override int GetHashCode()
+        {
+            return x.GetHashCode() ^ base.GetHashCode(); //Noncompliant
+        }
+        public override bool Equals(object obj)
+        {
+            return base.Equals(obj); //Noncompliant
+        }
+
+        public override string ToString()
+        {
+            return base.ToString();
+        }
+    }
+
+    class GetHashCodeEqualsOverride2
+    {
+        private readonly int x;
+        public GetHashCodeEqualsOverride2(int x)
+        {
+            this.x = x;
+        }
+        public override int GetHashCode()
+        {
+            return x.GetHashCode();
+        }
+    }
+
+    class GetHashCodeEqualsOverride3 : GetHashCodeEqualsOverride2
+    {
+        private readonly int x;
+        public GetHashCodeEqualsOverride3(int x) : base(x)
+        {
+            this.x = x;
+        }
+        public override int GetHashCode()
+        {
+            return x.GetHashCode() ^ base.GetHashCode();
+        }
+
+        public override string ToString()
+        {
+            return base.ToString();
+        }
+    }
+
+    class Base
+    { }
+
+    class Derived : Base
+    {
+        public override int GetHashCode()
+        {
+            return base.GetHashCode(); //Noncompliant, calls object.GetHashCode()
+        }
+    }
+}


### PR DESCRIPTION
…s()'

Fixes #76