### PR TITLE
Issue #211 In S1172 ignore methods that are passed to delegates ...

### DIFF
--- a/src/SonarLint/Rules.Description/S1172.html
+++ b/src/SonarLint/Rules.Description/S1172.html
@@ -20,7 +20,7 @@ void DoSomething(int a)
 
 <h2>Exceptions</h2>
 <p>
-    <code>virtual</code>, <code>override</code> methods and interface implementations are ignored.
+    <code>virtual</code>, <code>override</code> methods, interface implementations and methods that are passed to a delegate or eventhandler.
 </p>
 <pre>
 override void DoSomething(int a, int b) // no issue reported on b

--- a/src/Tests/SonarLint.UnitTest/TestCases/MethodParameterUnused.cs
+++ b/src/Tests/SonarLint.UnitTest/TestCases/MethodParameterUnused.cs
@@ -1,8 +1,5 @@
 ﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
+using System.Threading;
 
 namespace Tests.TestCases
 {
@@ -23,6 +20,26 @@ namespace Tests.TestCases
 
     class MethodParameterUnused : Base, IMy
     {
+        public event EventHandler MyEvent;
+
+        public MethodParameterUnused()
+        {
+            // AddAssignmentExpression
+            MyEvent += MethodParameterUnused_MyEvent;
+
+            // VariableDeclarator
+            WaitCallback c = W1;
+
+            // SimpleAssignmentExpression
+            c = W2;
+
+            // Argument
+            ThreadPool.QueueUserWorkItem(W3);
+
+            // InvocationExpression
+            W4(null);
+        }
+
         public void M1(int a) //Noncompliant
         {
         }
@@ -42,5 +59,25 @@ namespace Tests.TestCases
 
         public void M4(int a) //okay
         { }
+
+        private void MethodParameterUnused_MyEvent(object sender, EventArgs e)
+        {
+        }
+
+        static void W1(object state)
+        {
+        }
+
+        static void W2(object state)
+        {
+        }
+
+        static void W3(object state)
+        {
+        }
+
+        static void W4(object state) //Noncompliant
+        {
+        }
     }
 }


### PR DESCRIPTION
…or event handlers

A project I work on has very large number of warnings due to this issue. So I thought this is a great time to start learning about Roslyn code analyzers and try to fix it myself.

I think I've got a solution that works. I have verified against a modified version of the existing MethodParameterUnused test. But the ItSources_Match_Expected_All test fails and I have no idea how to geet this test green. I would appreciate some help on this.