### PR TITLE
Event names should not have 'Before' or 'After' as a prefix or suffix

### DIFF
--- a/src/SonarLint/Rules.Description/S2349.html
+++ b/src/SonarLint/Rules.Description/S2349.html
@@ -1,0 +1,20 @@
+<p>
+    "After" and "Before" prefixes or suffixes should not be used to indicate pre and post events. The concepts of before and
+    after should be given to events using the present and past tense.
+</p>
+
+<h2>Noncompliant Code Example</h2>
+<pre>
+Class Foo
+    Event BeforeClose() ' Noncompliant
+    Event AfterClose()  ' Noncompliant
+End Class
+</pre>
+
+<h2>Compliant Solution</h2>
+<pre>
+Class Foo
+    Event Closing()     ' Compliant
+    Event Closed()      ' Compliant
+End Class
+</pre>

--- a/src/SonarLint/Rules/EventNameContainsBeforeOrAfter.cs
+++ b/src/SonarLint/Rules/EventNameContainsBeforeOrAfter.cs
@@ -1,0 +1,103 @@
+﻿/*
+ * SonarLint for Visual Studio
+ * Copyright (C) 2015 SonarSource
+ * sonarqube@googlegroups.com
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02
+ */
+
+using System.Collections.Immutable;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.VisualBasic;
+using Microsoft.CodeAnalysis.VisualBasic.Syntax;
+using Microsoft.CodeAnalysis.Diagnostics;
+using SonarLint.Common;
+using SonarLint.Common.Sqale;
+using SonarLint.Helpers;
+
+namespace SonarLint.Rules
+{
+    [DiagnosticAnalyzer(LanguageNames.VisualBasic)]
+    [SqaleConstantRemediation("5min")]
+    [SqaleSubCharacteristic(SqaleSubCharacteristic.Understandability)]
+    [Rule(DiagnosticId, RuleSeverity, Title, IsActivatedByDefault)]
+    [Tags(Tag.Convention)]
+    public class EventNameContainsBeforeOrAfter : DiagnosticAnalyzer
+    {
+        internal const string DiagnosticId = "S2349";
+        internal const string Title = "Event names should not have \"Before\" or \"After\" as a prefix or suffix";
+        internal const string Description =
+            "\"After\" and \"Before\" prefixes or suffixes should not be used to indicate pre and post events. The concepts of " +
+            "before and after should be given to events using the present and past tense.";
+        internal const string MessageFormat = "Rename this event to remove the \"{0}\" {1}.";
+        internal const string Category = Constants.SonarLint;
+        internal const Severity RuleSeverity = Severity.Minor;
+        internal const bool IsActivatedByDefault = true;
+
+        internal static readonly DiagnosticDescriptor Rule =
+            new DiagnosticDescriptor(DiagnosticId, Title, MessageFormat, Category,
+                RuleSeverity.ToDiagnosticSeverity(), IsActivatedByDefault,
+                helpLinkUri: DiagnosticId.GetHelpLink(),
+                description: Description);
+
+        public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics { get { return ImmutableArray.Create(Rule); } }
+
+        private const string PrefixLiteral = "prefix";
+        private const string SuffixLiteral = "suffix";
+        private const string AfterLiteral = "after";
+        private const string BeforeLiteral = "before";
+
+        public override void Initialize(AnalysisContext context)
+        {
+            context.RegisterSyntaxNodeActionInNonGenerated(
+                c =>
+                {
+                    var eventStatement = (EventStatementSyntax)c.Node;
+                    var name = eventStatement.Identifier.ValueText;
+
+                    string part;
+                    string matched;
+
+                    if (name.StartsWith(BeforeLiteral, System.StringComparison.InvariantCultureIgnoreCase))
+                    {
+                        part = PrefixLiteral;
+                        matched = name.Substring(0, BeforeLiteral.Length);
+                    }
+                    else if (name.StartsWith(AfterLiteral, System.StringComparison.InvariantCultureIgnoreCase))
+                    {
+                        part = PrefixLiteral;
+                        matched = name.Substring(0, AfterLiteral.Length);
+                    }
+                    else if (name.EndsWith(BeforeLiteral, System.StringComparison.InvariantCultureIgnoreCase))
+                    {
+                        part = SuffixLiteral;
+                        matched = name.Substring(name.Length - 1 - BeforeLiteral.Length);
+                    }
+                    else if (name.EndsWith(AfterLiteral, System.StringComparison.InvariantCultureIgnoreCase))
+                    {
+                        part = SuffixLiteral;
+                        matched = name.Substring(name.Length - 1 - AfterLiteral.Length);
+                    }
+                    else
+                    {
+                        return;
+                    }
+
+                    c.ReportDiagnostic(Diagnostic.Create(Rule, eventStatement.Identifier.GetLocation(), matched, part));
+                },
+                SyntaxKind.EventStatement);
+        }
+    }
+}

--- a/src/SonarLint/SonarLint.csproj
+++ b/src/SonarLint/SonarLint.csproj
@@ -109,6 +109,7 @@
     <Compile Include="Helpers\EquivalenceChecker.cs" />
     <Compile Include="Helpers\ProjectTypeHelper.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
+    <Compile Include="Rules\EventNameContainsBeforeOrAfter.cs" />
     <Compile Include="Rules\FieldShouldNotBePublicBase.cs" />
     <Compile Include="Rules\PublicConstantField.cs" />
     <Compile Include="Rules\PublicConstantFieldBase.cs" />
@@ -684,6 +685,9 @@
   </ItemGroup>
   <ItemGroup>
     <EmbeddedResource Include="Rules.Description\S2340.html" />
+  </ItemGroup>
+  <ItemGroup>
+    <EmbeddedResource Include="Rules.Description\S2349.html" />
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it.

--- a/src/Tests/SonarLint.RulingTest/Expected/VisualBasic/S2349.json
+++ b/src/Tests/SonarLint.RulingTest/Expected/VisualBasic/S2349.json
@@ -1,0 +1,13 @@
+{
+  "Version": "0.1",
+  "ToolInfo": {
+    "ToolName": "SonarLint.RulingTest",
+    "FileVersion": "1.0.0"
+  },
+  "Issues": [
+    {
+      "RuleId": "S2349",
+      "Locations": []
+    }
+  ]
+}

--- a/src/Tests/SonarLint.RulingTest/SonarLint.RulingTest.csproj
+++ b/src/Tests/SonarLint.RulingTest/SonarLint.RulingTest.csproj
@@ -497,6 +497,9 @@
     <None Include="Expected\VisualBasic\S2340.json">
       <CopyToOutputDirectory>Always</CopyToOutputDirectory>
     </None>
+    <None Include="Expected\VisualBasic\S2349.json">
+      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+    </None>
     <None Include="Expected\VisualBasic\S2351.json">
       <CopyToOutputDirectory>Always</CopyToOutputDirectory>
     </None>

--- a/src/Tests/SonarLint.UnitTest/Rules/EventNameContainsBeforeOrAfterTest.cs
+++ b/src/Tests/SonarLint.UnitTest/Rules/EventNameContainsBeforeOrAfterTest.cs
@@ -1,0 +1,36 @@
+﻿/*
+ * SonarLint for Visual Studio
+ * Copyright (C) 2015 SonarSource
+ * sonarqube@googlegroups.com
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02
+ */
+
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using SonarLint.Rules;
+
+namespace SonarLint.UnitTest.Rules
+{
+    [TestClass]
+    public class EventNameContainsBeforeOrAfterTest
+    {
+        [TestMethod]
+        [TestCategory("Rule")]
+        public void EventNameContainsBeforeOrAfter()
+        {
+            Verifier.VerifyAnalyzer(@"TestCases\EventNameContainsBeforeOrAfter.vb", new EventNameContainsBeforeOrAfter());
+        }
+    }
+}

--- a/src/Tests/SonarLint.UnitTest/SonarLint.UnitTest.csproj
+++ b/src/Tests/SonarLint.UnitTest/SonarLint.UnitTest.csproj
@@ -136,6 +136,7 @@
     <Compile Include="Helpers\EquivalenceCheckerTest.cs" />
     <Compile Include="Common\MetricsTest.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
+    <Compile Include="Rules\EventNameContainsBeforeOrAfterTest.cs" />
     <Compile Include="Rules\PropertyWithArrayTypeTest.cs" />
     <Compile Include="Rules\ArrayInitializationMultipleStatementsTest.cs" />
     <Compile Include="Rules\ArrayCreationLongSyntaxTest.cs" />
@@ -880,6 +881,9 @@
   </ItemGroup>
   <ItemGroup>
     <None Include="TestCases\SimpleDoLoop.vb">
+      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+    </None>
+    <None Include="TestCases\EventNameContainsBeforeOrAfter.vb">
       <CopyToOutputDirectory>Always</CopyToOutputDirectory>
     </None>
   </ItemGroup>

--- a/src/Tests/SonarLint.UnitTest/TestCases/EventNameContainsBeforeOrAfter.vb
+++ b/src/Tests/SonarLint.UnitTest/TestCases/EventNameContainsBeforeOrAfter.vb
@@ -1,0 +1,20 @@
+﻿Class Foo
+    Event BeforeClose() ' Noncompliant
+    Event afterClose()  ' Noncompliant
+    Event Closing()
+    Public Custom Event BeforeClose2 As EventHandler ' Noncompliant
+        AddHandler(ByVal value As EventHandler)
+            Me.Events.AddHandler(Me.EventServerChange, value)
+        End AddHandler
+
+
+        RemoveHandler(ByVal value As EventHandler)
+            Me.Events.RemoveHandler(Me.EventServerChange, value)
+        End RemoveHandler
+
+
+        RaiseEvent(ByVal sender As Object, ByVal e As System.EventArgs)
+            CType(Me.Events(Me.EventServerChange), EventHandler).Invoke(sender, e)
+        End RaiseEvent
+    End Event
+End Class


### PR DESCRIPTION
Fixes #472 