### PR TITLE
"base.Equals" should not be used to check for reference equality in "Equals" override

### DIFF
--- a/src/SonarLint.CSharp/SonarLint.CSharp.csproj
+++ b/src/SonarLint.CSharp/SonarLint.CSharp.csproj
@@ -163,6 +163,7 @@
     <Compile Include="Rules\GenericTypeParameterEmptinessCheckingCodeFixProvider.cs" />
     <Compile Include="Rules\GenericTypeParameterInOut.cs" />
     <Compile Include="Rules\GenericTypeParameterUnused.cs" />
+    <Compile Include="Rules\GuardConditionOnEqualsOverride.cs" />
     <Compile Include="Rules\GetHashCodeEqualsOverride.cs" />
     <Compile Include="Rules\GetHashCodeMutable.cs" />
     <Compile Include="Rules\GetHashCodeMutableCodeFixProvider.cs" />

--- a/src/SonarLint.Extra/Rules.Description/S3397.html
+++ b/src/SonarLint.Extra/Rules.Description/S3397.html
@@ -1,0 +1,76 @@
+<p>
+    <code>object.Equals()</code> overrides can be optimized by checking first for reference equality between <code>this</code> and the
+    parameter. This check can be implemented by calling <code>object.ReferenceEquals()</code> or <code>base.Equals()</code>, where
+    <code>base</code> is <code>object</code>. However, using <code>base.Equals()</code> is a maintenance hazard because while it works
+    if you extend <code>Object</code> directly, if you introduce a new base class that overrides <code>Equals</code>, it suddenly stops
+    working.
+</p>
+<p>
+    This rule raises an issue if <code>base.Equals()</code> is used but <code>base</code> is not <code>object</code>.
+</p>
+
+<h2>Noncompliant Code Example</h2>
+<pre>
+class Base
+{
+  private int baseField;
+
+  public override bool Equals(object other)
+  {
+    if (base.Equals(other)) // Okay; base is object
+    {
+      return true;
+    }
+
+    return this.baseField == ((Base)other).baseField;
+  }
+}
+
+class Derived : Base
+{
+  private int derivedField;
+
+  public override bool Equals(object other)
+  {
+    if (base.Equals(other))  // Noncompliant
+    {
+      return true;
+    }
+
+    return this.derivedField == ((Derived)other).derivedField;
+  }
+}
+</pre>
+
+<h2>Compliant Solution</h2>
+<pre>
+class Base
+{
+  private int baseField;
+
+  public override bool Equals(object other)
+  {
+    if (object.ReferenceEquals(this, other))  // base.Equals is okay here, but object.ReferenceEquals is better
+    {
+      return true;
+    }
+
+    return this.baseField == ((Base)other).baseField;
+  }
+}
+
+class Derived : Base
+{
+  private int derivedField;
+
+  public override bool Equals(object other)
+  {
+    if (object.ReferenceEquals(this, other))
+    {
+      return true;
+    }
+
+    return base.Equals(other) &amp;&amp; this.derivedField == ((Derived)other).derivedField;
+  }
+}
+</pre>

--- a/src/SonarLint.Extra/SonarLint.Extra.csproj
+++ b/src/SonarLint.Extra/SonarLint.Extra.csproj
@@ -582,6 +582,9 @@
   </ItemGroup>
   <ItemGroup>
     <EmbeddedResource Include="Rules.Description\S3427.html" />
+    </ItemGroup>
+  <ItemGroup>
+    <EmbeddedResource Include="Rules.Description\S3397.html" />
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it.

--- a/src/Tests/SonarLint.RulingTest/Expected/CSharp/S3397.json
+++ b/src/Tests/SonarLint.RulingTest/Expected/CSharp/S3397.json
@@ -1,0 +1,13 @@
+{
+  "Version": "0.1",
+  "ToolInfo": {
+    "ToolName": "SonarLint.RulingTest",
+    "FileVersion": "1.0.0"
+  },
+  "Issues": [
+    {
+      "RuleId": "S3397",
+      "Locations": []
+    }
+  ]
+}

--- a/src/Tests/SonarLint.RulingTest/SonarLint.RulingTest.csproj
+++ b/src/Tests/SonarLint.RulingTest/SonarLint.RulingTest.csproj
@@ -494,6 +494,9 @@
     <None Include="Expected\CSharp\S3427.json">
       <CopyToOutputDirectory>Always</CopyToOutputDirectory>
     </None>
+    <None Include="Expected\CSharp\S3397.json">
+      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+    </None>
     <None Include="Expected\CSharp\S818.json">
       <CopyToOutputDirectory>Always</CopyToOutputDirectory>
     </None>

--- a/src/Tests/SonarLint.UnitTest/Rules/EqualsOverrideTest.cs
+++ b/src/Tests/SonarLint.UnitTest/Rules/EqualsOverrideTest.cs
@@ -1,0 +1,36 @@
+﻿/*
+ * SonarLint for Visual Studio
+ * Copyright (C) 2015 SonarSource
+ * sonarqube@googlegroups.com
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02
+ */
+
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using SonarLint.Rules.CSharp;
+
+namespace SonarLint.UnitTest.Rules
+{
+    [TestClass]
+    public class GuardConditionOnEqualsOverrideTest
+    {
+        [TestMethod]
+        [TestCategory("Rule")]
+        public void GuardConditionOnEqualsOverride()
+        {
+            Verifier.VerifyAnalyzer(@"TestCases\GuardConditionOnEqualsOverride.cs", new GuardConditionOnEqualsOverride());
+        }
+    }
+}

--- a/src/Tests/SonarLint.UnitTest/SonarLint.UnitTest.csproj
+++ b/src/Tests/SonarLint.UnitTest/SonarLint.UnitTest.csproj
@@ -140,6 +140,7 @@
     <Compile Include="Common\MetricsTest.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="Rules\CommentTodoTest.cs" />
+    <Compile Include="Rules\EqualsOverrideTest.cs" />
     <Compile Include="Rules\EventNameContainsBeforeOrAfterTest.cs" />
     <Compile Include="Rules\ExitStatementUsageTest.cs" />
     <Compile Include="Rules\InvocationResolvesToOverrideWithParamsTest.cs" />
@@ -720,6 +721,9 @@
       <CopyToOutputDirectory>Always</CopyToOutputDirectory>
     </None>
     <None Include="TestCases\MethodOverloadOptionalParameter.cs">
+      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+    </None>
+    <None Include="TestCases\GuardConditionOnEqualsOverride.cs">
       <CopyToOutputDirectory>Always</CopyToOutputDirectory>
     </None>
     <Compile Include="Verifier.cs" />

--- a/src/Tests/SonarLint.UnitTest/TestCases/GuardConditionOnEqualsOverride.cs
+++ b/src/Tests/SonarLint.UnitTest/TestCases/GuardConditionOnEqualsOverride.cs
@@ -1,0 +1,28 @@
+﻿using System;
+using System.Collections.Generic;
+
+namespace Tests.Diagnostics
+{
+    class Base
+    {
+        public override bool Equals(object other)
+        {
+            if (base.Equals(other)) // Okay; base is object
+            {
+                return true;
+            }
+            // do some checks here
+        }
+    }
+    class Derived : Base
+    {
+        public override bool Equals(object other)
+        {
+            if (base.Equals(other))  // Noncompliant
+            {
+                return true;
+            }
+            // do some checks here
+        }
+    }
+}


### PR DESCRIPTION
Fixes #621 