### PR TITLE
reload SonarLint.xml settings when the file changes, and debugging improvements

### DIFF
--- a/src/SonarLint.Vsix/SonarLint.Vsix.csproj
+++ b/src/SonarLint.Vsix/SonarLint.Vsix.csproj
@@ -24,6 +24,7 @@
     <IncludeDebugSymbolsInLocalVSIXDeployment>false</IncludeDebugSymbolsInLocalVSIXDeployment>
     <CopyBuildOutputToOutputDirectory>false</CopyBuildOutputToOutputDirectory>
     <CopyOutputSymbolsToOutputDirectory>false</CopyOutputSymbolsToOutputDirectory>
+    <VSSDKTargetPlatformRegRootSuffix>Roslyn</VSSDKTargetPlatformRegRootSuffix>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <DebugSymbols>true</DebugSymbols>
@@ -45,6 +46,11 @@
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
     <CodeAnalysisRuleSet>..\SonarLint.ruleset</CodeAnalysisRuleSet>
+  </PropertyGroup>
+  <PropertyGroup>
+    <StartAction>Program</StartAction>
+    <StartProgram>$(DevEnvDir)devenv.exe</StartProgram>
+    <StartArguments>/rootsuffix Roslyn</StartArguments>
   </PropertyGroup>
   <ItemGroup>
     <None Include="app.config" />

--- a/src/SonarLint/Helpers/ParameterLoader.cs
+++ b/src/SonarLint/Helpers/ParameterLoader.cs
@@ -41,11 +41,26 @@ namespace SonarLint.Helpers
         {
             public string ParameterKey { get; set; }
             public string ParameterValue { get; set; }
+
+            public override string ToString()
+            {
+                return $"{ParameterKey} = {ParameterValue}";
+            }
         }
         public class RuleParameterValues
         {
             public string RuleId { get; set; }
             public List<RuleParameterValue> ParameterValues { get; set; } = new List<RuleParameterValue>();
+
+            public override string ToString()
+            {
+                string display = $"{RuleId}";
+                foreach (RuleParameterValue parameterValue in ParameterValues)
+                {
+                    display += $" | {parameterValue}";
+                }
+                return display;
+            }
         }
 
         //todo: this can become private when we remove the template rule


### PR DESCRIPTION
I wanted to be able to play with the settings in SonarLint.xml in my project, but changes to the file were not taking affect. This is because the setting had already been loaded into ProcessedAnalyzers, and the code does not reload them. 

I made changes to track the timestamp of SonarLint.xml so that it would reload the settings if the file has changed since it was loaded last. 

NOTE: Existing warnings in a code file do not appear to be refreshed by Visual Studio until the code file is modified, so to verify this you will need to modify SonarLint.xml and then modify the code file being analyzed.

I also added some debugging improvements in the process of working on this. The csproj changes allow you run the vsix project and load symbols so that breakpoints can be hit. The ToString() overrides make it easier to see the values of the parameters in debug windows.