### PR TITLE
#740 Improve the performance of the FIXME and TODO rules

### DIFF
--- a/its/expected/akka.net/Akka.Cluster-{6AB00F61-269A-4501-B06A-026707F000A7}-S1135.json
+++ b/its/expected/akka.net/Akka.Cluster-{6AB00F61-269A-4501-B06A-026707F000A7}-S1135.json
@@ -45,6 +45,36 @@
 "uri":  "akka.net\\src\\core\\Akka.Cluster\\AutoDown.cs",
 "region":  {
 "startLine":  21,
+"startColumn":  55,
+"endLine":  21,
+"endColumn":  59
+}
+}
+]
+}
+],
+"shortMessage":  "Complete the task associated to this \"TODO\" comment.",
+"fullMessage":  "\"TODO\" tags are commonly used to mark places where some more code is required, but which the developer wants to implement later. Sometimes the developer will not have the time or will simply forget to get back to that tag. This rule is meant to track those tags, and ensure that they do not go unnoticed.",
+"properties":  {
+"severity":  "Warning",
+"warningLevel":  "1",
+"defaultSeverity":  "Info",
+"title":  "\"TODO\" tags should be handled",
+"category":  "Maintainability",
+"helpLink":  "http://vs.sonarlint.org/rules/index.html#version=1.7.0\u0026ruleId=S1135",
+"isEnabledByDefault":  "True",
+"isSuppressedInSource":  "False"
+}
+},
+{
+"ruleId":  "S1135",
+"locations":  [
+{
+"analysisTarget":  [
+{
+"uri":  "akka.net\\src\\core\\Akka.Cluster\\AutoDown.cs",
+"region":  {
+"startLine":  21,
 "startColumn":  68,
 "endLine":  21,
 "endColumn":  72

--- a/src/SonarLint.CSharp/Rules/CommentFixme.cs
+++ b/src/SonarLint.CSharp/Rules/CommentFixme.cs
@@ -29,9 +29,9 @@ namespace SonarLint.Rules.CSharp
     [DiagnosticAnalyzer(LanguageNames.CSharp)]
     [NoSqaleRemediation]
     [Rule(DiagnosticId, RuleSeverity, Title, IsActivatedByDefault)]
-    public class CommentFixme : CommentRegularExpressionBase
+    public class CommentFixme : CommentWordBase
     {
-        protected override string RegularExpression => "(?i).*(FIXME).*";
+        protected override string Word => "FIXME";
 
         internal const string DiagnosticId = "S1134";
         internal const string Title = "\"FIXME\" tags should be handled";

--- a/src/SonarLint.CSharp/Rules/CommentTodo.cs
+++ b/src/SonarLint.CSharp/Rules/CommentTodo.cs
@@ -29,9 +29,9 @@ namespace SonarLint.Rules.CSharp
     [DiagnosticAnalyzer(LanguageNames.CSharp)]
     [NoSqaleRemediation]
     [Rule(DiagnosticId, RuleSeverity, Title, IsActivatedByDefault)]
-    public class CommentTodo : CommentRegularExpressionBase
+    public class CommentTodo : CommentWordBase
     {
-        protected override string RegularExpression => "(?i).*(TODO).*";
+        protected override string Word => "TODO";
 
         internal const string DiagnosticId = "S1135";
         internal const string Title = "\"TODO\" tags should be handled";

--- a/src/SonarLint.CSharp/SonarLint.CSharp.csproj
+++ b/src/SonarLint.CSharp/SonarLint.CSharp.csproj
@@ -120,7 +120,7 @@
     <Compile Include="Rules\CommentedOutCode.cs" />
     <Compile Include="Rules\CommentFixme.cs" />
     <Compile Include="Rules\CommentTodo.cs" />
-    <Compile Include="Rules\CommentRegularExpressionBase.cs" />
+    <Compile Include="Rules\CommentWordBase.cs" />
     <Compile Include="Rules\ConditionalSimplification.cs" />
     <Compile Include="Rules\ConditionalSimplificationCodeFixProvider.cs" />
     <Compile Include="Rules\ConditionalStructureSameCondition.cs" />


### PR DESCRIPTION
Fixes #740 

With this PR, we're getting the following performance:
```
SonarLint.Rules.CSharp.CommentTodo                                       0.552 
SonarLint.Rules.CSharp.SingleStatementPerLine                            0.509 
SonarLint.Rules.CSharp.CommentFixme                                      0.508 
```

Instead of:
```
SonarLint.Rules.CSharp.CommentFixme                                      8.453 
SonarLint.Rules.CSharp.CommentTodo                                       8.083 
```